### PR TITLE
Explained version selector fix

### DIFF
--- a/toolbox/fdc3-explained/1.0/index.html
+++ b/toolbox/fdc3-explained/1.0/index.html
@@ -19,17 +19,6 @@
     </tr>
 
 		<tr>
-			<td class="header">FDC3 Version:</td>
-			<td>
-				<select id="versions" onchange="window.location.href=`../${this.value}`">
-          <option value="1.0" selected>1.0</option>
-          <option value="1.1">1.1</option>
-          <option value="1.2">1.2</option>
-				</select>
-			</td>
-		</tr>
-
-		<tr>
 			<td colspan="3"><hr/></td>
 		</tr>
 

--- a/toolbox/fdc3-explained/1.1/index.html
+++ b/toolbox/fdc3-explained/1.1/index.html
@@ -30,17 +30,6 @@
 			</tr>
 
 			<tr>
-				<td class="header">FDC3 Version:</td>
-				<td>
-          <select id="versions" onchange="window.location.href=`../${this.value}`">
-            <option value="1.0">1.0</option>
-            <option value="1.1" selected>1.1</option>
-            <option value="1.2">1.2</option>
-          </select>
-				</td>
-			</tr>
-
-			<tr>
 				<td colspan="3"><hr/></td>
 			</tr>
 

--- a/toolbox/fdc3-explained/1.2/index.html
+++ b/toolbox/fdc3-explained/1.2/index.html
@@ -29,13 +29,7 @@
 
 			<tr>
 				<td class="header">FDC3 Version:</td>
-				<td>
-          <select id="versions" onchange="window.location.href=`../${this.value}`">
-            <option value="1.0">1.0</option>
-            <option value="1.1">1.1</option>
-            <option value="1.2" selected>1.2</option>
-          </select>
-				</td>
+				<td><span id="fdc3Details">None</span></td>
 			</tr>
 
 			<tr>

--- a/toolbox/fdc3-explained/1.2/main.js
+++ b/toolbox/fdc3-explained/1.2/main.js
@@ -58,11 +58,17 @@ function getPlatform() {
 
   //providerDetails.innerHTML = `${fdc3Info.provider} ${fdc3Info.providerVersion}`;
   updateProviderDetails(`${fdc3Info.provider} ${fdc3Info.providerVersion}`);
+  updateFDC3Version(`${fdc3Info.fdc3Version}`);
 }
 
 function updateProviderDetails(details){
   const providerDetails = document.getElementById('providerDetails');
   providerDetails.innerText = details;
+}
+
+function updateFDC3Version(details){
+  const fdc3Details = document.getElementById('fdc3Details');
+  fdc3Details.innerText = details;
 }
 
 async function populateHTML() {

--- a/toolbox/fdc3-explained/index.html
+++ b/toolbox/fdc3-explained/index.html
@@ -13,6 +13,11 @@
         color: white;
       }
 
+      a  {
+        color: white;
+        text-decoration: none;
+      }
+
       .main {
         margin: 10px 0;
         padding: 0;
@@ -26,7 +31,6 @@
         width: 25%;
         padding: 5px;
         text-align: center;
-        cursor: pointer;
         font-weight: 700;
       }
 
@@ -66,14 +70,14 @@
           </td>
         </tr>
         <tr>
-          <td class="linkbox acceptable" onClick="window.location.href='1.0/';">
-            1.0
+          <td class="linkbox acceptable">
+            <a href="1.0/"">1.0</a>
           </td>
-          <td class="linkbox acceptable" onClick="window.location.href='1.1/';">
-            1.1
+          <td class="linkbox acceptable">
+            <a href="1.1/"">1.1</a>
           </td>
-          <td class="linkbox optimal" onClick="window.location.href='1.2/';">
-            1.2
+          <td class="linkbox optimal">
+            <a href="1.2/"">1.2</a>
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Changed the navigation links on the main page and removed the version selector in 1.0 and 1.1 as well as replaced it on 1.2 with the actual FDC3 version - as originally intended.